### PR TITLE
support internal exchanges

### DIFF
--- a/api/v1beta1/exchange_types.go
+++ b/api/v1beta1/exchange_types.go
@@ -30,6 +30,10 @@ type ExchangeSpec struct {
 	Durable bool `json:"durable,omitempty"`
 	// Cannot be updated
 	AutoDelete bool `json:"autoDelete,omitempty"`
+	// When true clients cannot publish to this exchange directly.
+	// It then may only be used with exchange-to-exchange bindings.
+	// Channot be updated.
+	Internal bool `json:"internal,omitempty"`
 	// +kubebuilder:validation:Type=object
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Arguments *runtime.RawExtension `json:"arguments,omitempty"`

--- a/api/v1beta1/exchange_webhook.go
+++ b/api/v1beta1/exchange_webhook.go
@@ -26,7 +26,7 @@ func (e *Exchange) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 // returns error type 'forbidden' for updates that the controller chooses to disallow: exchange name/vhost/rabbitmqClusterReference
-// returns error type 'invalid' for updates that will be rejected by rabbitmq server: exchange types/autoDelete/durable
+// returns error type 'invalid' for updates that will be rejected by rabbitmq server: exchange types/autoDelete/durable/internal
 // exchange.spec.arguments can be updated
 func (e *Exchange) ValidateUpdate(old runtime.Object) error {
 	oldExchange, ok := old.(*Exchange)
@@ -70,8 +70,16 @@ func (e *Exchange) ValidateUpdate(old runtime.Object) error {
 	if e.Spec.Durable != oldExchange.Spec.Durable {
 		allErrs = append(allErrs, field.Invalid(
 			field.NewPath("spec", "durable"),
-			e.Spec.AutoDelete,
+			e.Spec.Durable,
 			"durable cannot be updated",
+		))
+	}
+
+	if e.Spec.Internal != oldExchange.Spec.Internal {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec", "internal"),
+			e.Spec.Internal,
+			"internal cannot be updated",
 		))
 	}
 

--- a/api/v1beta1/exchange_webhook_test.go
+++ b/api/v1beta1/exchange_webhook_test.go
@@ -20,6 +20,7 @@ var _ = Describe("exchange webhook", func() {
 			Type:       "fanout",
 			Durable:    false,
 			AutoDelete: true,
+                        Internal:   false,
 			RabbitmqClusterReference: RabbitmqClusterReference{
 				Name: "some-cluster",
 			},
@@ -61,6 +62,12 @@ var _ = Describe("exchange webhook", func() {
 	It("does not allow updates on autoDelete", func() {
 		newExchange := exchange.DeepCopy()
 		newExchange.Spec.AutoDelete = false
+		Expect(apierrors.IsInvalid(newExchange.ValidateUpdate(&exchange))).To(BeTrue())
+	})
+
+	It("does not allow updates on internal", func() {
+		newExchange := exchange.DeepCopy()
+		newExchange.Spec.Internal = true
 		Expect(apierrors.IsInvalid(newExchange.ValidateUpdate(&exchange))).To(BeTrue())
 	})
 

--- a/config/crd/bases/rabbitmq.com_exchanges.yaml
+++ b/config/crd/bases/rabbitmq.com_exchanges.yaml
@@ -47,6 +47,11 @@ spec:
               durable:
                 description: Cannot be updated
                 type: boolean
+              internal:
+                description: When true clients cannot publish to this exchange directly.
+                  It then may only be used with exchange-to-exchange bindings.
+                  Cannot be updated
+                type: boolean
               name:
                 description: Required property; cannot be updated
                 type: string

--- a/docs/examples/exchanges/internal-topic-exchange.yaml
+++ b/docs/examples/exchanges/internal-topic-exchange.yaml
@@ -1,0 +1,16 @@
+# More on topic exchanges and other exchange types, see: https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchanges.
+# Regarding the internal option, see https://www.rabbitmq.com/amqp-0-9-1-reference.html#exchange.declare.internal
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Exchange
+metadata:
+  name: topic
+spec:
+  name: topic-exchange # name of the exchange
+  vhost: "/test-vhost" # default to '/' if not provided
+  type: topic
+  autoDelete: false
+  durable: true
+  internal: true
+  rabbitmqClusterReference:
+    name: test

--- a/internal/exchange_settings.go
+++ b/internal/exchange_settings.go
@@ -27,6 +27,7 @@ func GenerateExchangeSettings(e *topology.Exchange) (*rabbithole.ExchangeSetting
 	return &rabbithole.ExchangeSettings{
 		Durable:    e.Spec.Durable,
 		AutoDelete: e.Spec.AutoDelete,
+                Internal:   e.Spec.Internal,
 		Type:       e.Spec.Type,
 		Arguments:  arguments,
 	}, nil

--- a/internal/exchange_settings_test.go
+++ b/internal/exchange_settings_test.go
@@ -21,6 +21,7 @@ var _ = Describe("GenerateExchangeSettings", func() {
 				Type:       "fanout",
 				Durable:    true,
 				AutoDelete: true,
+				Internal:   false,
 			},
 		}
 	})
@@ -42,6 +43,13 @@ var _ = Describe("GenerateExchangeSettings", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(settings.Durable).To(BeTrue())
 	})
+
+	It("sets Internal according to exchange.spec", func() {
+		settings, err := internal.GenerateExchangeSettings(e)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(settings.Internal).To(BeFalse())
+	})
+
 
 	When("exchange arguments are provided", func() {
 		It("generates the correct exchange arguments", func() {

--- a/system_tests/exchange_system_test.go
+++ b/system_tests/exchange_system_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Exchange", func() {
 				Type:       "fanout",
 				AutoDelete: false,
 				Durable:    true,
+                                Internal:   false,
 				Arguments: &runtime.RawExtension{
 					Raw: []byte(`{"alternate-exchange": "system-test"}`),
 				},
@@ -61,6 +62,7 @@ var _ = Describe("Exchange", func() {
 			"Type":       Equal(exchange.Spec.Type),
 			"AutoDelete": BeFalse(),
 			"Durable":    BeTrue(),
+                        "Internal":   BeFalse(),
 		}))
 		Expect(exchangeInfo.Arguments).To(HaveKeyWithValue("alternate-exchange", "system-test"))
 


### PR DESCRIPTION
WIP

If set, the exchange may not be used directly by publishers, but only when bound to other exchanges.
Internal exchanges are used to construct wiring that is not visible to applications.

https://www.rabbitmq.com/amqp-0-9-1-reference.html#exchange.declare.internal

This closes #

**Note to reviewers:** remember to look at the commits in this PR and consider if they can be squashed
**Note to contributors:** remember to re-generate client set if there are any API changes

## Summary Of Changes

## Additional Context
